### PR TITLE
v3 53: Add breadcrumbs

### DIFF
--- a/tech-far-hub/.vscode/settings.json
+++ b/tech-far-hub/.vscode/settings.json
@@ -1,8 +1,20 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.validate": ["javascript"]
+  "eslint.validate": ["javascript"],
+  // The number of spaces a tab is equal to. This setting is overridden
+  // based on the file contents when `editor.detectIndentation` is true.
+  "editor.tabSize": 2,
+
+  // Insert spaces when pressing Tab. This setting is overriden
+  // based on the file contents when `editor.detectIndentation` is true.
+  "editor.insertSpaces": true,
+
+  // When opening a file, `editor.tabSize` and `editor.insertSpaces`
+  // will be detected based on the file contents. Set to false to keep
+  // the values you've explicitly set, above.
+  "editor.detectIndentation": false
 }

--- a/tech-far-hub/gatsby-node.ts
+++ b/tech-far-hub/gatsby-node.ts
@@ -1,5 +1,4 @@
 import type { GatsbyNode } from "gatsby";
-import { withPrefix } from "gatsby";
 import path from "path";
 
 interface ITemplatedNode {
@@ -81,8 +80,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
     const pageName: string = node.parent.name;
     const pageIdentifier: string = node.frontmatter.slug || pageName;
 
-    const pagePath =
-      pageName == "index" ? `${parentDirs}/` : `${parentDirs}/${pageIdentifier}/`;
+    const pagePath = pageName == "index" ? `/${parentDirs}/` : `/${parentDirs}/${pageIdentifier}/`;
     const heading = node.frontmatter?.heading;
     return {
       ...node,
@@ -96,7 +94,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
   const getHeadingForPath = (path: string) => {
     for (let node of nodes) {
       if (path === "/") return "Home";
-      if (node.pagePath == path) return node.heading;
+      if (node.pagePath === path) return node.heading;
     }
     return undefined;
   };
@@ -123,6 +121,11 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
         ["label", breadCrumbHeadings[i]],
       ])
     );
+    console.log({
+      id: node.id,
+      breadCrumbs,
+      pathParts,
+    });
     createPage({
       path: pagePath,
       component: `${template}?__contentFilePath=${node.internal.contentFilePath}`,

--- a/tech-far-hub/gatsby-node.ts
+++ b/tech-far-hub/gatsby-node.ts
@@ -1,4 +1,5 @@
 import type { GatsbyNode } from "gatsby";
+import { withPrefix } from "gatsby";
 import path from "path";
 
 interface ITemplatedNode {
@@ -12,10 +13,19 @@ interface ITemplatedNode {
   };
   frontmatter: {
     slug?: string;
+    heading?: string;
   };
   internal: {
     contentFilePath: string;
   };
+}
+
+interface IEnhancedTemplatedNode extends ITemplatedNode {
+  pagePath: string;
+  parentDirs: string;
+  pageName: string;
+  pageIdentifier: string;
+  heading?: string;
 }
 
 interface ITemplateNodeResultSet {
@@ -33,7 +43,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
   const { createPage } = actions;
 
   const result: IGraphQLTemplateNodeResult = await graphql(`
-    {
+    query CreatePages {
       allMdx {
         edges {
           node {
@@ -50,6 +60,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
             }
             frontmatter {
               slug
+              heading
             }
             internal {
               contentFilePath
@@ -65,21 +76,60 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
     return;
   }
 
-  result.data.allMdx.edges.forEach(({ node }: { node: ITemplatedNode }) => {
+  const nodes: IEnhancedTemplatedNode[] = result.data.allMdx.edges.map(({ node }: { node: ITemplatedNode }) => {
     const parentDirs: string = node.parent.relativeDirectory;
-    const contentType: string = node.parent.relativeDirectory.split(path.sep)[0];
     const pageName: string = node.parent.name;
-    const pageIdentier: string = node.frontmatter.slug || pageName;
+    const pageIdentifier: string = node.frontmatter.slug || pageName;
+
+    const pagePath =
+      pageName == "index" ? withPrefix(`${parentDirs}/`) : withPrefix(`${parentDirs}/${pageIdentifier}/`);
+    const heading = node.frontmatter?.heading;
+    return {
+      ...node,
+      pagePath,
+      parentDirs,
+      pageName,
+      pageIdentifier,
+      heading,
+    };
+  });
+  const getHeadingForPath = (path: string) => {
+    for (let node of nodes) {
+      if (path === "/") return "Home";
+      if (node.pagePath == path) return node.heading;
+    }
+    return undefined;
+  };
+
+  nodes.forEach((node: IEnhancedTemplatedNode) => {
+    const contentType: string = node.parent.relativeDirectory.split(path.sep)[0];
 
     // TODO: Make page-specific templates more general
-    const templateName = pageName === "index" ? "template-index.tsx" : "template-default.tsx";
-    const pagePath = pageName == "index" ? `${parentDirs}/` : `${parentDirs}/${pageIdentier}/`;
+    const templateName = node.pageName === "index" ? "template-index.tsx" : "template-default.tsx";
+    const pagePath = node.pageName == "index" ? `${node.parentDirs}/` : `${node.parentDirs}/${node.pageIdentifier}/`;
     const template = path.resolve("src", "pages", contentType, templateName);
+    const pathParts = node.pagePath.replace(/\/$/, "").split("/");
+    const breadCrumbPaths = pathParts.reduce(
+      (accumulator: string[], currentValue: string) => [
+        ...accumulator,
+        [accumulator[accumulator.length - 1], currentValue, ""].join("/").replace("//", "/"),
+      ],
+      []
+    );
+    const breadCrumbHeadings = breadCrumbPaths.map(getHeadingForPath);
+    const breadCrumbs = breadCrumbPaths.map((path, i) =>
+      Object.fromEntries([
+        ["path", path],
+        ["label", breadCrumbHeadings[i]],
+      ])
+    );
     createPage({
       path: pagePath,
       component: `${template}?__contentFilePath=${node.internal.contentFilePath}`,
       context: {
         id: node.id,
+        breadCrumbs,
+        pathParts,
       },
     });
   });

--- a/tech-far-hub/gatsby-node.ts
+++ b/tech-far-hub/gatsby-node.ts
@@ -82,7 +82,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
     const pageIdentifier: string = node.frontmatter.slug || pageName;
 
     const pagePath =
-      pageName == "index" ? withPrefix(`${parentDirs}/`) : withPrefix(`${parentDirs}/${pageIdentifier}/`);
+      pageName == "index" ? `${parentDirs}/` : `${parentDirs}/${pageIdentifier}/`;
     const heading = node.frontmatter?.heading;
     return {
       ...node,
@@ -106,7 +106,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
 
     // TODO: Make page-specific templates more general
     const templateName = node.pageName === "index" ? "template-index.tsx" : "template-default.tsx";
-    const pagePath = node.pageName == "index" ? `${node.parentDirs}/` : `${node.parentDirs}/${node.pageIdentifier}/`;
+    const pagePath = node.pagePath;
     const template = path.resolve("src", "pages", contentType, templateName);
     const pathParts = node.pagePath.replace(/\/$/, "").split("/");
     const breadCrumbPaths = pathParts.reduce(

--- a/tech-far-hub/package-lock.json
+++ b/tech-far-hub/package-lock.json
@@ -21,6 +21,7 @@
         "gatsby-transformer-sharp": "^5.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-use": "^17.4.0",
         "sass": "^1.56.1"
       },
       "devDependencies": {
@@ -3669,6 +3670,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -4195,6 +4201,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -5941,6 +5952,14 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.24.1.tgz",
@@ -6065,6 +6084,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
       }
     },
     "node_modules/css-loader": {
@@ -8044,6 +8071,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-loops": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+    },
+    "node_modules/fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
@@ -8051,6 +8088,11 @@
       "engines": {
         "node": ">= 4.9.1"
       }
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -9960,6 +10002,11 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -10091,6 +10138,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
+      }
     },
     "node_modules/inquirer": {
       "version": "7.3.3",
@@ -10726,6 +10782,11 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -12331,6 +12392,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "node_modules/nano-css": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.5.tgz",
+      "integrity": "sha512-vSB9X12bbNu4ALBu7nigJgRViZ6ja3OU7CeuiV1zMIbXOdmkLahgtPmh3GBOlDxbKY0CitqlPdOReGlBLSp+yg==",
+      "dependencies": {
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -14387,6 +14467,40 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "peerDependencies": {
+        "react": "*",
+        "tslib": "*"
+      }
+    },
+    "node_modules/react-use": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.4.0.tgz",
+      "integrity": "sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==",
+      "dependencies": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.3.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -14823,6 +14937,11 @@
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
       "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -15118,6 +15237,14 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.0.tgz",
+      "integrity": "sha512-Oc7PnzwIEU4M0K1J4h/7qUUaljXhQ0kCObRsZjxs2HjkpKsnoTMvSmvJ4sqgJZd0zBoEfAyTdnK/jMIYvrjySQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -15286,6 +15413,17 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -15411,6 +15549,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "node_modules/set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+      "engines": {
+        "node": ">=6.9"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -15819,6 +15965,11 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
     },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
@@ -15873,6 +16024,14 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -15885,6 +16044,33 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -16167,6 +16353,11 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+    },
     "node_modules/sudo-prompt": {
       "version": "8.2.5",
       "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.5.tgz",
@@ -16410,6 +16601,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -16475,6 +16674,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -16546,6 +16750,11 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
       "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
+    },
+    "node_modules/ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -20212,6 +20421,11 @@
         "@types/node": "*"
       }
     },
+    "@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -20642,6 +20856,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -21945,6 +22164,14 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.24.1.tgz",
@@ -22043,6 +22270,14 @@
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
       "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
       "requires": {}
+    },
+    "css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.3"
+      }
     },
     "css-loader": {
       "version": "5.2.7",
@@ -23498,10 +23733,25 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "fast-loops": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+    },
+    "fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
     "fastest-levenshtein": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
       "integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA=="
+    },
+    "fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -24923,6 +25173,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -25006,6 +25261,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+    },
+    "inline-style-prefixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+      "requires": {
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
+      }
     },
     "inquirer": {
       "version": "7.3.3",
@@ -25441,6 +25705,11 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -26553,6 +26822,21 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nano-css": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.5.tgz",
+      "integrity": "sha512-vSB9X12bbNu4ALBu7nigJgRViZ6ja3OU7CeuiV1zMIbXOdmkLahgtPmh3GBOlDxbKY0CitqlPdOReGlBLSp+yg==",
+      "requires": {
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
+      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -27960,6 +28244,33 @@
         }
       }
     },
+    "react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "requires": {}
+    },
+    "react-use": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.4.0.tgz",
+      "integrity": "sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==",
+      "requires": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.3.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -28304,6 +28615,11 @@
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
       "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -28533,6 +28849,14 @@
         "glob": "^7.1.3"
       }
     },
+    "rtl-css-js": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.0.tgz",
+      "integrity": "sha512-Oc7PnzwIEU4M0K1J4h/7qUUaljXhQ0kCObRsZjxs2HjkpKsnoTMvSmvJ4sqgJZd0zBoEfAyTdnK/jMIYvrjySQ==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -28630,6 +28954,11 @@
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
       }
+    },
+    "screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
     },
     "section-matter": {
       "version": "1.0.0",
@@ -28738,6 +29067,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -29047,6 +29381,11 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "space-separated-tokens": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
@@ -29088,6 +29427,14 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -29097,6 +29444,32 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA=="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "statuses": {
       "version": "2.0.1",
@@ -29312,6 +29685,11 @@
         "postcss-selector-parser": "^6.0.4"
       }
     },
+    "stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+    },
     "sudo-prompt": {
       "version": "8.2.5",
       "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.5.tgz",
@@ -29490,6 +29868,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -29543,6 +29926,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
     "toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -29591,6 +29979,11 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
       "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
+    },
+    "ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/tech-far-hub/package.json
+++ b/tech-far-hub/package.json
@@ -29,6 +29,7 @@
     "gatsby-transformer-sharp": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-use": "^17.4.0",
     "sass": "^1.56.1"
   },
   "devDependencies": {

--- a/tech-far-hub/src/components/breadcrumbs.tsx
+++ b/tech-far-hub/src/components/breadcrumbs.tsx
@@ -3,8 +3,8 @@ import { BreadcrumbBar, BreadcrumbLink, Breadcrumb } from "@trussworks/react-usw
 import { IBreadcrumb } from "../types";
 import { withPrefix } from "gatsby";
 
-export const Breadcrumbs = ({ breadCrumbs }: { breadCrumbs: [IBreadcrumb] }) => {
-  const rows = [];
+export const Breadcrumbs = ({ breadCrumbs }: { breadCrumbs: IBreadcrumb[] }) => {
+  const rows: JSX.Element[] = [];
   breadCrumbs.forEach((crumbData, index) => {
     if (index < breadCrumbs.length - 1) {
       rows.push(

--- a/tech-far-hub/src/components/breadcrumbs.tsx
+++ b/tech-far-hub/src/components/breadcrumbs.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { BreadcrumbBar, BreadcrumbLink, Breadcrumb } from "@trussworks/react-uswds";
+import { IBreadcrumb } from "../types";
+import { withPrefix } from "gatsby";
+
+export const Breadcrumbs = ({ breadCrumbs }: { breadCrumbs: [IBreadcrumb] }) => {
+  const rows = [];
+  breadCrumbs.forEach((crumbData, index) => {
+    if (index < breadCrumbs.length - 1) {
+      rows.push(
+        <Breadcrumb>
+          <BreadcrumbLink href={withPrefix(crumbData.path)}>
+            <span>{crumbData.label}</span>
+          </BreadcrumbLink>
+        </Breadcrumb>
+      );
+    } else {
+      rows.push(
+        <Breadcrumb current>
+          <span>{crumbData.label}</span>
+        </Breadcrumb>
+      );
+    }
+  });
+  return <BreadcrumbBar>{rows}</BreadcrumbBar>;
+};

--- a/tech-far-hub/src/components/layout.tsx
+++ b/tech-far-hub/src/components/layout.tsx
@@ -12,7 +12,7 @@ import { IBreadcrumb } from "../types";
 
 interface ILayoutProps {
   children: ReactNode;
-  breadCrumbs?: [IBreadcrumb];
+  breadCrumbs?: IBreadcrumb[];
 }
 
 const Layout = ({ children, breadCrumbs }: ILayoutProps) => {

--- a/tech-far-hub/src/components/layout.tsx
+++ b/tech-far-hub/src/components/layout.tsx
@@ -7,12 +7,15 @@ import "./tfh.scss";
 import { GovBanner, GridContainer, Grid, Header, Title, NavMenuButton } from "@trussworks/react-uswds";
 import Navigation from "./navigation";
 import Footer from "./footer";
+import { Breadcrumbs } from "./breadcrumbs";
+import { IBreadcrumb } from "../types";
 
 interface ILayoutProps {
   children: ReactNode;
+  breadCrumbs?: [IBreadcrumb];
 }
 
-const Layout = ({ children }: ILayoutProps) => {
+const Layout = ({ children, breadCrumbs }: ILayoutProps) => {
   const [navExpanded, setNavExpanded] = React.useState(false);
   const onNavExpand = (): void => setNavExpanded((prvExpanded) => !prvExpanded);
 
@@ -35,6 +38,13 @@ const Layout = ({ children }: ILayoutProps) => {
 
       <main id="main-content">
         <GridContainer>
+          <Grid row>
+            {breadCrumbs && (
+              <Grid col="fill">
+                <Breadcrumbs breadCrumbs={breadCrumbs}></Breadcrumbs>{" "}
+              </Grid>
+            )}
+          </Grid>
           <Grid row>
             <Grid col="fill">{children}</Grid>
           </Grid>

--- a/tech-far-hub/src/components/navigation.tsx
+++ b/tech-far-hub/src/components/navigation.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
-import { withPrefix, Link } from "gatsby";
+import { Link } from "gatsby";
+import { USWDS_BREAKPOINTS } from "../settings";
+import { useWindowSize } from "react-use";
 
 import { NavDropDownButton, Menu, ExtendedNav, Search } from "@trussworks/react-uswds";
 
@@ -10,6 +12,7 @@ interface iNavigation {
   onNavExpanded: onClickHandler;
 }
 const Navigation = ({ isNavExpanded, onNavExpanded }: iNavigation) => {
+  const { width } = useWindowSize();
   const [isOpen, setIsOpen] = React.useState([false, false, false]);
   /**
    * This toggle function will handle all navigation toggle links
@@ -19,17 +22,29 @@ const Navigation = ({ isNavExpanded, onNavExpanded }: iNavigation) => {
   const onToggle = (index: number): void => {
     // The setIsOpen is used to toggle the currently selected nav link
     setIsOpen((prevIsOpen) => {
-      const newIsOpen = [...isOpen];
-      newIsOpen[index] = !prevIsOpen[index];
-
-      // TODO Implement auto-closing at desktop size, ala j40
+      let newIsOpen: Array<boolean>;
+      if (width >= USWDS_BREAKPOINTS.DESKTOP) {
+        // On desktop, only allow one menu item to be open at a time
+        newIsOpen = new Array(isOpen.length).fill(false);
+        newIsOpen[index] = !prevIsOpen[index];
+      } else {
+        // On mobile, allow several to open at a time
+        newIsOpen = [...isOpen];
+        newIsOpen[index] = !prevIsOpen[index];
+      }
       return newIsOpen;
     });
   };
 
   const getStartedSubItems = [<Link to="/get-started">Get Started</Link>];
-
-  const handbookItems = [<a href="#start">First item</a>];
+  const secondaryLinks = [
+    <a href="#privacy" key="privacy">
+      Privacy Policy
+    </a>,
+    <a href="#latest-updates" key="updates">
+      Latest Updates
+    </a>,
+  ];
 
   const subMenuItems = [
     <a href="#linkOne" key="one">
@@ -58,41 +73,32 @@ const Navigation = ({ isNavExpanded, onNavExpanded }: iNavigation) => {
         onToggle={(): void => {
           onToggle(1);
         }}
-        menuId="learningCenterDropdown"
+        menuId="preSolicitationDropdown"
         isOpen={isOpen[1]}
-        label="Learning Center"
+        label="Pre-Solicitation"
         isCurrent={false}
       />
-      <Menu key="learningCenter" items={subMenuItems} isOpen={isOpen[1]} />
+      <Menu key="preSolicitation" items={subMenuItems} isOpen={isOpen[1]} />
     </>,
 
-    <a href="#two" key="caseStudies" className="usa-nav__link">
-      <span>Case Studies</span>
+    <a href="#two" key="solicitations" className="usa-nav__link">
+      <span>Solicitation</span>
     </a>,
-    <a href="#three" key="samples" className="usa-nav__link">
-      <span>Samples &amp; Templates</span>
+    <a href="#three" key="evaluation" className="usa-nav__link">
+      <span>Evaluation</span>
     </a>,
-    <>
-      <NavDropDownButton
-        onToggle={(): void => {
-          onToggle(2);
-        }}
-        menuId="handbookDropdown"
-        isOpen={isOpen[2]}
-        label="Handbook"
-        isCurrent={false}
-      />
-      <Menu key="handbook" items={handbookItems} isOpen={isOpen[2]} />
-    </>,
+    <a href="#three" key="contactAdministration" className="usa-nav__link">
+      <span>Contract Administration</span>
+    </a>,
     <a href="#three" key="history" className="usa-nav__link">
-      <span>History of TFH</span>
+      <span>Resources</span>
     </a>,
   ];
   return (
     <>
       <ExtendedNav
         primaryItems={mainNavItems}
-        secondaryItems={[]}
+        secondaryItems={secondaryLinks}
         mobileExpanded={isNavExpanded}
         onToggleMobileNav={onNavExpanded}
       >

--- a/tech-far-hub/src/pages/get-started/template-default.tsx
+++ b/tech-far-hub/src/pages/get-started/template-default.tsx
@@ -4,11 +4,9 @@ import { graphql } from "gatsby";
 import Layout from "../../components/layout";
 import { IPageContext } from "../../types";
 
-const LifecyclePage: React.FC<PageProps<Queries.GetStartedInnerPageQuery>> = ({
-  data,
-  children,
-  pageContext,
-}: PageProps<Queries.GetStartedInnerPageQuery>) => {
+type LifecyclePageProps = PageProps<Queries.GetStartedInnerPageQuery, IPageContext>;
+
+const LifecyclePage: React.FC<LifecyclePageProps> = ({ data, children, pageContext }: LifecyclePageProps) => {
   return (
     <Layout breadCrumbs={pageContext.breadCrumbs}>
       <h2>{data.mdx?.frontmatter?.heading}</h2>

--- a/tech-far-hub/src/pages/get-started/template-default.tsx
+++ b/tech-far-hub/src/pages/get-started/template-default.tsx
@@ -2,13 +2,15 @@ import * as React from "react";
 import type { HeadFC, PageProps } from "gatsby";
 import { graphql } from "gatsby";
 import Layout from "../../components/layout";
+import { IPageContext } from "../../types";
 
 const LifecyclePage: React.FC<PageProps<Queries.GetStartedInnerPageQuery>> = ({
   data,
   children,
+  pageContext,
 }: PageProps<Queries.GetStartedInnerPageQuery>) => {
   return (
-    <Layout>
+    <Layout breadCrumbs={pageContext.breadCrumbs}>
       <h2>{data.mdx?.frontmatter?.heading}</h2>
       {children}
     </Layout>

--- a/tech-far-hub/src/pages/get-started/template-index.tsx
+++ b/tech-far-hub/src/pages/get-started/template-index.tsx
@@ -7,9 +7,10 @@ import Layout from "../../components/layout";
 const GetStartedPage: React.FC<PageProps<Queries.GetStartedPageQuery>> = ({
   data,
   children,
+  pageContext,
 }: PageProps<Queries.GetStartedPageQuery>) => {
   return (
-    <Layout>
+    <Layout breadCrumbs={pageContext.breadCrumbs}>
       <h2>{data.getStarted?.frontmatter?.heading}</h2>
       <hr className="text-accent-warm " />
       {children}

--- a/tech-far-hub/src/pages/get-started/template-index.tsx
+++ b/tech-far-hub/src/pages/get-started/template-index.tsx
@@ -3,12 +3,11 @@ import type { HeadFC } from "gatsby";
 import { graphql, Link, PageProps } from "gatsby";
 import { CardGroup, Card, CardHeader, CardBody, CardFooter, Button } from "@trussworks/react-uswds";
 import Layout from "../../components/layout";
+import { IPageContext } from "../../types";
 
-const GetStartedPage: React.FC<PageProps<Queries.GetStartedPageQuery>> = ({
-  data,
-  children,
-  pageContext,
-}: PageProps<Queries.GetStartedPageQuery>) => {
+type GetStartedProps = PageProps<Queries.GetStartedPageQuery, IPageContext>;
+
+const GetStartedPage: React.FC<GetStartedProps> = ({ data, children, pageContext }: GetStartedProps) => {
   return (
     <Layout breadCrumbs={pageContext.breadCrumbs}>
       <h2>{data.getStarted?.frontmatter?.heading}</h2>

--- a/tech-far-hub/src/pages/get-started/template-index.tsx
+++ b/tech-far-hub/src/pages/get-started/template-index.tsx
@@ -16,7 +16,7 @@ const GetStartedPage: React.FC<PageProps<Queries.GetStartedPageQuery>> = ({
       <p className="usa-updated">Updated: {data.getStarted?.frontmatter?.updated}</p>
       <CardGroup>
         {data.lifecycle.nodes.map((node) => (
-          <Card headerFirst gridLayout={{ tablet: { col: 3 } }}>
+          <Card headerFirst gridLayout={{ tablet: { col: 3 } }} key={node.frontmatter?.slug}>
             <CardHeader className="bg-base-lightest">
               <h3 className="usa-card__heading">
                 {node.frontmatter?.lifecycle_stage} {node.frontmatter?.heading}

--- a/tech-far-hub/src/pages/index.tsx
+++ b/tech-far-hub/src/pages/index.tsx
@@ -1,17 +1,15 @@
-import * as React from "react"
-import type { HeadFC, PageProps } from "gatsby"
-import Layout from '../components/layout'
+import * as React from "react";
+import type { HeadFC, PageProps } from "gatsby";
+import Layout from "../components/layout";
 
-
-
-const IndexPage: React.FC<PageProps> = () => {
+const IndexPage: React.FC<PageProps> = ({ pageContext }) => {
   return (
     <Layout>
       <h1>Hello world</h1>
     </Layout>
-  )
-}
+  );
+};
 
-export default IndexPage
+export default IndexPage;
 
-export const Head: HeadFC = () => <title>TechFAR Hub</title>
+export const Head: HeadFC = () => <title>TechFAR Hub</title>;

--- a/tech-far-hub/src/pages/index.tsx
+++ b/tech-far-hub/src/pages/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type { HeadFC, PageProps } from "gatsby";
 import Layout from "../components/layout";
 
-const IndexPage: React.FC<PageProps> = ({ pageContext }) => {
+const IndexPage: React.FC<PageProps> = () => {
   return (
     <Layout>
       <h1>Hello world</h1>

--- a/tech-far-hub/src/settings.tsx
+++ b/tech-far-hub/src/settings.tsx
@@ -1,0 +1,5 @@
+// USWDS Breakpoints
+export const USWDS_BREAKPOINTS = {
+  MOBILE_LG: 480,
+  DESKTOP: 1024,
+};

--- a/tech-far-hub/src/types.ts
+++ b/tech-far-hub/src/types.ts
@@ -1,3 +1,5 @@
+import { PageProps } from "gatsby";
+
 export interface IBreadcrumb {
   label: string;
   path: string;
@@ -5,6 +7,6 @@ export interface IBreadcrumb {
 
 export interface IPageContext {
   id: string;
-  breadCrumbs: [IBreadcrumb];
-  pathParts: [string];
+  breadCrumbs: IBreadcrumb[];
+  pathParts: string[];
 }

--- a/tech-far-hub/src/types.ts
+++ b/tech-far-hub/src/types.ts
@@ -1,0 +1,10 @@
+export interface IBreadcrumb {
+  label: string;
+  path: string;
+}
+
+export interface IPageContext {
+  id: string;
+  breadCrumbs: [IBreadcrumb];
+  pathParts: [string];
+}


### PR DESCRIPTION
This branch revises the infrastructure setup in mattbowen-usds/v3-51-get-started-round1 to:

- Add breadcrumb data to page requests and a breadcrumb component 
- Fix type annotations throughout
- Run a formatter on pretty much all the code.
- Adjusts the dropdowns on desktop so only one is ever open at a time