### PR TITLE
Add resources homepage

### DIFF
--- a/tech-far-hub/content/components/resources-home/case-studies.md
+++ b/tech-far-hub/content/components/resources-home/case-studies.md
@@ -1,0 +1,8 @@
+---
+heading: Case Studies
+href: /resources/case-studies
+nav_weight: 10
+visible: true
+---
+
+Get inspired and learn from your peers through case studies.

--- a/tech-far-hub/content/components/resources-home/policies.md
+++ b/tech-far-hub/content/components/resources-home/policies.md
@@ -1,0 +1,8 @@
+---
+heading: Policy & Guidance
+href: /resources/policy-guidance/
+nav_weight: 30
+visible: true
+---
+
+Find relevant memos, FAQs, and other guidance to protect your procurement from successful protest.

--- a/tech-far-hub/content/components/resources-home/samples.md
+++ b/tech-far-hub/content/components/resources-home/samples.md
@@ -1,0 +1,8 @@
+---
+heading: Templates, Samples & Tools
+href: /resources/templates-samples/
+nav_weight: 10
+visible: true
+---
+
+Learn from previous success with our sample procurement documents.

--- a/tech-far-hub/content/components/resources-home/templates.md
+++ b/tech-far-hub/content/components/resources-home/templates.md
@@ -1,0 +1,8 @@
+---
+heading: Contracts & Vehicles
+href: /resources/templates-samples/
+nav_weight: 40
+visible: true
+---
+
+Find templates for contract vehicles, scopes of work, etc.

--- a/tech-far-hub/content/resources/index.mdx
+++ b/tech-far-hub/content/resources/index.mdx
@@ -1,8 +1,14 @@
 ---
 slug: index
 heading: Resources
-template: default
+template: resources-landing
 page_type: landing
 ---
-
-Resources to come
+<ExternalResources heading="Learning Center" media="/assets/img/manik-roy-pYYpgTClGgI-unsplash.jpg">
+- [Acquisition Principles](learning-center/acquisition-principals)
+- [Digital IT Acquisition Professional Training (DITAP)](learning-center/training)
+- [Agency Maturity for Agile](learning-center/agency-maturity-for-agile)
+- [News & Podcasts](learning-center/news-podcasts)
+- [Field Guides](learning-center/field-guides)
+- [History of TFH](learning-center/history-of-tfh)
+</ExternalResources>

--- a/tech-far-hub/src/components/resouces-card.tsx
+++ b/tech-far-hub/src/components/resouces-card.tsx
@@ -1,0 +1,38 @@
+import { Card, CardHeader, CardBody, CardFooter } from "@trussworks/react-uswds";
+import { ColumnSizes } from "@trussworks/react-uswds/lib/components/grid/types";
+import { Link } from "gatsby";
+import * as React from "react";
+
+interface IResourceNode {
+  html: string | null;
+  frontmatter: {
+    href: string | null;
+    heading: string | null;
+  } | null;
+}
+
+const ResouceCard = ({ node, width = 3 }: { node: IResourceNode; width?: ColumnSizes }): JSX.Element => {
+  if (node.html && node.frontmatter && node.frontmatter.href) {
+    return (
+      <Card headerFirst gridLayout={{ tablet: { col: width } }}>
+        <CardHeader>
+          <h4>{node.frontmatter.heading}</h4>
+        </CardHeader>
+        <CardBody dangerouslySetInnerHTML={{ __html: node.html }}></CardBody>
+        <CardFooter>
+          <Link to={node.frontmatter.href} className="usa-button">
+            View {node.frontmatter.heading}
+          </Link>
+        </CardFooter>
+      </Card>
+    );
+  } else {
+    return (
+      <Card headerFirst>
+        <CardHeader>ERROR in Resouces Snippet</CardHeader>
+      </Card>
+    );
+  }
+};
+
+export default ResouceCard;

--- a/tech-far-hub/src/components/resources.tsx
+++ b/tech-far-hub/src/components/resources.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useStaticQuery, graphql, Link } from "gatsby";
 import { CardGroup, Card, CardHeader, CardBody, CardFooter } from "@trussworks/react-uswds";
-
+import ResouceCard from "./resouces-card";
 const Resources = () => {
   const data: Queries.ResourcePromosQuery = useStaticQuery(graphql`
     query ResourcePromos {
       allMarkdownRemark(
-        filter: { fileAbsolutePath: { regex: "/.*/components/.*/" }, frontmatter: { visible: { eq: true } } }
+        filter: { fileAbsolutePath: { regex: "/.*/components/resources/.*/" }, frontmatter: { visible: { eq: true } } }
         sort: { frontmatter: { nav_weight: ASC } }
       ) {
         edges {
@@ -34,25 +34,9 @@ const Resources = () => {
   `);
   return (
     <CardGroup>
-      {data.allMarkdownRemark.edges
-        .filter(({ node }) => node.html && node.frontmatter && node.frontmatter.href)
-        .map(({ node }) => {
-          if (node.html && node.frontmatter && node.frontmatter.href) {
-            return (
-              <Card headerFirst gridLayout={{ tablet: { col: 3 } }}>
-                <CardHeader>
-                  <h4>{node.frontmatter.heading}</h4>
-                </CardHeader>
-                <CardBody dangerouslySetInnerHTML={{ __html: node.html }}></CardBody>
-                <CardFooter>
-                  <Link to={node.frontmatter.href} className="usa-button">
-                    View {node.frontmatter.heading}
-                  </Link>
-                </CardFooter>
-              </Card>
-            );
-          }
-        })}
+      {data.allMarkdownRemark.edges.map(({ node }) => {
+        return <ResouceCard node={node}></ResouceCard>;
+      })}
     </CardGroup>
   );
 };

--- a/tech-far-hub/src/components/site-layout.tsx
+++ b/tech-far-hub/src/components/site-layout.tsx
@@ -12,9 +12,10 @@ import { IBreadcrumb } from "../types";
 interface ILayoutProps {
   children: ReactNode;
   breadCrumbs?: IBreadcrumb[];
+  className?: string;
 }
 
-const SiteLayout = ({ children, breadCrumbs }: ILayoutProps) => {
+const SiteLayout = ({ children, breadCrumbs, className }: ILayoutProps) => {
   const [navExpanded, setNavExpanded] = React.useState(false);
   const onNavExpand = (): void => setNavExpanded((prvExpanded) => !prvExpanded);
 
@@ -35,7 +36,7 @@ const SiteLayout = ({ children, breadCrumbs }: ILayoutProps) => {
         <Navigation isNavExpanded={navExpanded} onNavExpanded={onNavExpand} />
       </Header>
 
-      <main id="main-content">
+      <main id="main-content" className={className}>
         <GridContainer>
           <Grid row>
             {breadCrumbs && (

--- a/tech-far-hub/src/components/tfh.scss
+++ b/tech-far-hub/src/components/tfh.scss
@@ -167,4 +167,16 @@ li.usa-card {
       margin-top: 1rem;
     }
   }
+  .tfh-resources-landing .tfh-lifecycleResouces .usa-card__body {
+    min-height: 300px;
+    ul {
+      li {
+        flex: 250px;
+        margin-top: 2rem;
+        a {
+          color: color("ink");
+        }
+      }
+    }
+  }
 }

--- a/tech-far-hub/src/pages/template-default.tsx
+++ b/tech-far-hub/src/pages/template-default.tsx
@@ -1,13 +1,8 @@
-import { Grid, SideNav } from "@trussworks/react-uswds";
 import * as React from "react";
 import type { HeadFC, PageProps } from "gatsby";
 import { graphql, Link } from "gatsby";
 import SiteLayout from "../components/site-layout";
-import { DeepPick } from "ts-deep-pick";
 import MDXContent from "../components/mdxcontent";
-import Resources from "../components/resources";
-import { Alert } from "../components/alert";
-import { IPageContext } from "../types";
 import { TOCEnhancedQueryPageProps } from "../types";
 import PageLayoutNav from "../components/page-layout-nav";
 

--- a/tech-far-hub/src/pages/template-resources-landing.tsx
+++ b/tech-far-hub/src/pages/template-resources-landing.tsx
@@ -1,0 +1,65 @@
+import SiteLayout from "../components/site-layout";
+import MDXContent from "../components/mdxcontent";
+import { IPageContext } from "../types";
+import * as React from "react";
+import { graphql, PageProps } from "gatsby";
+import { CardGroup, Grid } from "@trussworks/react-uswds";
+import ResouceCard from "../components/resouces-card";
+
+type ResoucesPageProps = PageProps<Queries.ResourcesLandingContextQuery, IPageContext>;
+const ResoucesLandingPage: React.FC<ResoucesPageProps> = ({ data, children, pageContext }: ResoucesPageProps) => {
+  const pageHeading = data.currentPage?.frontmatter?.heading ?? "Resources";
+  return (
+    <SiteLayout breadCrumbs={pageContext.breadCrumbs} className="tfh-resources-landing">
+      <h1>{pageHeading}</h1>
+      <Grid row>
+        <MDXContent>{children}</MDXContent>
+      </Grid>
+      <Grid row>
+        <CardGroup>
+          {data.resourceLandPagePromos.edges.map(({ node }) => {
+            return <ResouceCard node={node} width={6}></ResouceCard>;
+          })}
+        </CardGroup>
+      </Grid>
+    </SiteLayout>
+  );
+};
+
+export default ResoucesLandingPage;
+
+export const query = graphql`
+  query ResourcesLandingContext($id: String) {
+    currentPage: mdx(id: { eq: $id }) {
+      ...minimalFrontmatter
+    }
+    resourceLandPagePromos: allMarkdownRemark(
+      filter: {
+        fileAbsolutePath: { regex: "/.*/components/resources-home/.*/" }
+        frontmatter: { visible: { eq: true } }
+      }
+      sort: { frontmatter: { nav_weight: ASC } }
+    ) {
+      edges {
+        node {
+          id
+          html
+          parent {
+            id
+            ... on File {
+              id
+              name
+              base
+              relativeDirectory
+              relativePath
+            }
+          }
+          frontmatter {
+            heading
+            href
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This adds a basic homepage design for the /resources landing page. To get there, I

*  Reused the external resources MDX component with a little custom styling for this application
* Duplicated the resources blocks

I'm a little bummed I had to copy some code for the graphql query for resources, but there's no good way to parameterize these :/