### PR TITLE
Allow for pages without sibling nav

### DIFF
--- a/tech-far-hub/content/resources/case-studies/VBA-salesforce-coe.mdx
+++ b/tech-far-hub/content/resources/case-studies/VBA-salesforce-coe.mdx
@@ -1,7 +1,7 @@
 ---
 slug: va-dot-gov-salesforce-coe
-template: default
-page_type: resources
+template: case-study
+page_type: case-study
 heading: Veterans Benefits Administration (VBA) Salesforce Center of Excellence, User-Centered Design Challenge
 promo_description: The VA Technology Acquisition Center worked with USDS and other VA stakeholders to conduct a user-centered design challenge to award a Task Order on the GSA Salesforce BPA.
 media_image: ../../static/assets/img/ux-indonesia-8mikJ83LmSQ-unsplash.jpg

--- a/tech-far-hub/content/resources/case-studies/va-dot-gov-modernization.mdx
+++ b/tech-far-hub/content/resources/case-studies/va-dot-gov-modernization.mdx
@@ -1,6 +1,6 @@
 ---
 slug: va-dot-gov-modernization
-template: default
+template: case-study
 page_type: case-study
 heading: VA dot gov Modernization - Comparative Analysis
 promo_description: The VA technology Acquisition Cent, in support of VA OIT/DSVA, utilized FAR 13.1 Simplified Acquisition Procedures, which enabled the team to streamline a multi-step evaluation with onsite demonstrations, and documented the evaluation using a comparative analysis.

--- a/tech-far-hub/content/resources/case-studies/va-mobile-apps-cloud-migration.mdx
+++ b/tech-far-hub/content/resources/case-studies/va-mobile-apps-cloud-migration.mdx
@@ -1,7 +1,7 @@
 ---
 slug: va-dot-gov-cloud-migration
-template: default
-page_type: resources
+template: case-study
+page_type: case-study
 heading: Department of Veterans (VA) Affairs Mobile Applications Cloud Migration Case Study
 promo_description: The VA Technology Acquisition Center, in support of VA OIT and VHA, along with assistance from USDS, utilized a Cloud Migration Technical Demonstration as part of an open market solicitation in order to better evaluate a vendors technical capability.
 media_image: ../../static/assets/img/ux-indonesia-8mikJ83LmSQ-unsplash.jpg

--- a/tech-far-hub/src/components/page-layout-nav.tsx
+++ b/tech-far-hub/src/components/page-layout-nav.tsx
@@ -25,6 +25,7 @@ interface IPageLayoutNav {
   tableOfContents: Record<string, ITOCItem[]>;
   pageContext: IPageContext;
   useNextLink: boolean;
+  showSiblings?: boolean;
   children: React.ReactNode;
 }
 
@@ -35,14 +36,16 @@ const PageLayoutNav: React.FC<IPageLayoutNav> = ({
   pageContext,
   children,
   useNextLink = false,
+  showSiblings = true,
 }: IPageLayoutNav) => {
   const currentSlug = frontmatter?.slug;
   const pathDepth = pageContext.pathParts.length;
   const isTopLevel = pathDepth === 2;
   const tocLinks = tableOfContents.items
     ? tableOfContents.items.map((item: ITOCItem) => {
+        const tocClass = !showSiblings ? "" : "font-ui-3xs";
         return (
-          <a href={item.url} key={item.url} className="font-ui-3xs">
+          <a href={item.url} key={item.url} className={tocClass}>
             {item.title}
           </a>
         );
@@ -78,13 +81,15 @@ const PageLayoutNav: React.FC<IPageLayoutNav> = ({
           atCurrent = true;
           return (
             <>
-              <a href="#" className="usa-current" key="current">
-                {node.frontmatter.heading}
-              </a>
+              {showSiblings === true && (
+                <a href="#" className="usa-current" key="current">
+                  {node.frontmatter.heading}
+                </a>
+              )}
               {tocLinks.length > 0 && <SideNav items={tocLinks}></SideNav>}
             </>
           );
-        } else {
+        } else if (showSiblings) {
           if (atCurrent) {
             nextLink = node.frontmatter;
             atCurrent = false;

--- a/tech-far-hub/src/components/page-layout-nav.tsx
+++ b/tech-far-hub/src/components/page-layout-nav.tsx
@@ -81,7 +81,7 @@ const PageLayoutNav: React.FC<IPageLayoutNav> = ({
           atCurrent = true;
           return (
             <>
-              {showSiblings === true && (
+              {showSiblings && (
                 <a href="#" className="usa-current" key="current">
                   {node.frontmatter.heading}
                 </a>

--- a/tech-far-hub/src/pages/template-case-study.tsx
+++ b/tech-far-hub/src/pages/template-case-study.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import type { HeadFC, PageProps } from "gatsby";
+import { graphql, Link } from "gatsby";
+import SiteLayout from "../components/site-layout";
+import MDXContent from "../components/mdxcontent";
+import { TOCEnhancedQueryPageProps } from "../types";
+import PageLayoutNav from "../components/page-layout-nav";
+
+type DefaultPageProps = TOCEnhancedQueryPageProps<Queries.CaseStudyPageContextQuery>;
+
+const DefaultPageTemplate: React.FC<DefaultPageProps> = ({ data, children, pageContext }: DefaultPageProps) => {
+  if (data.currentPage.frontmatter && data.siblings && data.currentPage.tableOfContents) {
+    return (
+      <PageLayoutNav
+        frontmatter={data.currentPage.frontmatter}
+        siblings={data.siblings}
+        tableOfContents={data.currentPage.tableOfContents}
+        pageContext={pageContext}
+        useNextLink={false}
+        showSiblings={false}
+      >
+        <MDXContent>{children}</MDXContent>
+      </PageLayoutNav>
+    );
+  }
+  return (
+    <SiteLayout>
+      <h1>Something went wrong</h1>
+    </SiteLayout>
+  );
+};
+
+export default DefaultPageTemplate;
+
+export const Head: HeadFC = () => <title>TechFAR Hub</title>;
+
+export const query = graphql`
+  query CaseStudyPageContext($id: String, $parentPathRegex: String) {
+    currentPage: mdx(id: { eq: $id }) {
+      ...currentPageWithLocalNav
+    }
+    siblings: allMdx(
+      filter: { internal: { contentFilePath: { regex: $parentPathRegex } } }
+      sort: { frontmatter: { nav_weight: ASC } }
+    ) {
+      nodes {
+        ...minimalFrontmatter
+        parent {
+          ... on File {
+            name
+            relativePath
+            relativeDirectory
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
- Add a flag to the global template to allow for not having sibling nav
- Add a new template for case studies that uses that flag
- Update case study metadata