### PR TITLE
Apply recent mock styling to site

### DIFF
--- a/tech-far-hub/src/components/page-layout-nav.tsx
+++ b/tech-far-hub/src/components/page-layout-nav.tsx
@@ -103,8 +103,6 @@ const PageLayoutNav: React.FC<IPageLayoutNav> = ({
   const components = { Alert };
   return (
     <SiteLayout breadCrumbs={pageContext.breadCrumbs}>
-      <h1>{frontmatter?.heading}</h1>
-      <hr className="text-accent-warm " />
       <Grid row gap={2} className="margin-bottom-4">
         <Grid tablet={{ col: 2 }}>
           <div className="position-sticky top-0">
@@ -112,6 +110,7 @@ const PageLayoutNav: React.FC<IPageLayoutNav> = ({
           </div>
         </Grid>
         <Grid tablet={{ col: 10 }}>
+          <h1>{frontmatter?.heading}</h1>
           {children}
           {useNextLink && nextLink !== null && (
             <span className="tfh-next-link">

--- a/tech-far-hub/src/components/site-layout.tsx
+++ b/tech-far-hub/src/components/site-layout.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ReactNode } from "react";
-import { Link } from "gatsby";
+import { Link, withPrefix } from "gatsby";
 import "./tfh.scss";
 
 import { GovBanner, GridContainer, Grid, Header, Title, NavMenuButton } from "@trussworks/react-uswds";
@@ -26,9 +26,13 @@ const SiteLayout = ({ children, breadCrumbs, className }: ILayoutProps) => {
         <div className="usa-navbar">
           <Title>
             <Link to="/">TechFAR Hub</Link>
-            {/* TODO: Replace with a real component and not inline styles */}
-            <em style={{ display: "block", fontSize: "50%", fontWeight: "normal" }}>
-              an initiative of US Digital Service
+            <em className="tfh-tagline">
+              <img
+                className="tfh-tagline-logo"
+                src={withPrefix("/images/usds-logo-footer.svg")}
+                alt="United States Digital Service"
+              />
+              <span>U.S. DIGITAL SERVICE</span>
             </em>
           </Title>
           <NavMenuButton onClick={onNavExpand} label="Menu" />

--- a/tech-far-hub/src/components/site-layout.tsx
+++ b/tech-far-hub/src/components/site-layout.tsx
@@ -33,11 +33,17 @@ const SiteLayout = ({ children, breadCrumbs, className }: ILayoutProps) => {
           </Title>
           <NavMenuButton onClick={onNavExpand} label="Menu" />
         </div>
-        <Navigation isNavExpanded={navExpanded} onNavExpanded={onNavExpand} />
+        <div className="tfh-nav-border"></div>
+        <GridContainer className="tfh-nav-grid">
+          <Grid row>
+            <Navigation isNavExpanded={navExpanded} onNavExpanded={onNavExpand} />
+          </Grid>
+        </GridContainer>
       </Header>
 
       <main id="main-content" className={className}>
         <GridContainer>
+          <hr className="tfh-top-hr" />
           <Grid row>
             {breadCrumbs && (
               <Grid col="fill">

--- a/tech-far-hub/src/components/summary.tsx
+++ b/tech-far-hub/src/components/summary.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
-import { SummaryBox, SummaryBoxContent, SummaryBoxHeading } from "@trussworks/react-uswds";
 
 export const Summary = ({ children, heading }: { children: React.ReactNode; heading?: string }): JSX.Element => {
   heading = heading ? heading : "Summary";
   return (
-    <SummaryBox>
-      <SummaryBoxHeading headingLevel="h3">{heading}</SummaryBoxHeading>
-      <SummaryBoxContent>{children}</SummaryBoxContent>
-    </SummaryBox>
+    <div className="usa-alert usa-alert--info">
+      <div className="usa-alert__body">
+        <h4 className="usa-alert__heading">{heading}</h4>
+        <p className="usa-alert__text">{children}</p>
+      </div>
+    </div>
   );
 };

--- a/tech-far-hub/src/components/tfh.scss
+++ b/tech-far-hub/src/components/tfh.scss
@@ -39,6 +39,34 @@ h1 {
   margin-top: 0;
 }
 
+.usa-logo__text a {
+  @include u-font("heading", "xl");
+  @include u-text("heavy");
+  padding-top: 1rem;
+}
+
+.usa-nav__secondary {
+  margin-top: 0;
+}
+em.tfh-tagline {
+  display: block;
+  font-size: 1rem;
+  font-weight: bold;
+  font-style: normal;
+  color: #103c68;
+  line-height: 2.5rem;
+
+  img {
+    display: inline;
+    height: 1.25rem;
+  }
+  span {
+    position: relative;
+    margin-left: 0.5rem;
+    top: -0.5rem;
+  }
+}
+
 .usa-breadcrumb__list-item.usa-current {
   font-weight: bold;
 }
@@ -187,7 +215,17 @@ li.usa-card {
   }
 }
 
+@include at-media-max("mobile-lg") {
+  .usa-navbar {
+    height: 100%;
+    margin-top: 0.5rem;
+  }
+}
+
 @include at-media("tablet") {
+  .usa-header--extended .usa-logo {
+    margin: 1rem 1.5rem 1rem 1.5rem;
+  }
   .tfh-hp-initiatives .usa-card__container {
     min-height: 210px;
   }

--- a/tech-far-hub/src/components/tfh.scss
+++ b/tech-far-hub/src/components/tfh.scss
@@ -24,6 +24,7 @@ $theme-hero-image: "#{$theme-image-path}/hero.png";
 $theme-font-role-heading: "sans";
 $theme-global-paragraph-styles: true;
 $theme-global-link-styles: true;
+$theme-link-color: "ink";
 
 @import "../../node_modules/uswds/dist/scss/uswds.scss";
 // @import "../../node_modules/@trussworks/react-uswds/lib"
@@ -34,9 +35,33 @@ p {
   max-width: unset;
 }
 
+h1 {
+  margin-top: 0;
+}
+
+.usa-breadcrumb__list-item.usa-current {
+  font-weight: bold;
+}
+
+.usa-breadcrumb__link span {
+  text-decoration: none;
+}
+
 .tfh-hp-top {
   @include u-border-bottom("1px");
   border-color: color("base-lighter");
+}
+
+.tfh-top-hr {
+  background-color: color("primary-dark");
+  color: color("primary-dark");
+  border: none;
+  height: 5px;
+  margin-top: 1rem;
+}
+
+.tfh-home .tfh-top-hr {
+  display: none;
 }
 
 .tfh-hp-highlight {
@@ -53,10 +78,21 @@ p {
   }
 }
 
+.tfh-nav-border {
+  border-bottom: 1px solid color("base-lighter");
+  width: 100%;
+  height: 1px;
+}
+
+.usa-header--extended .usa-nav {
+  border-top: none;
+}
+
 .tfh-hp-highlight-desc {
   margin-top: 0;
   max-width: unset;
 }
+
 .tfh-hp-right-nav {
   @include u-padding-y("205");
   ol {
@@ -71,6 +107,12 @@ p {
     margin: 0 auto;
     border: none;
   }
+}
+
+.tfh-resources-bar hr {
+  border: none;
+  background-color: color("base-lighter");
+  height: 2px;
 }
 
 .usa-footer {

--- a/tech-far-hub/src/pages/index.tsx
+++ b/tech-far-hub/src/pages/index.tsx
@@ -31,7 +31,7 @@ const IndexPage: React.FC<PageProps<Queries.HomePageInitiativesQuery>> = ({
     }
   });
   return (
-    <SiteLayout>
+    <SiteLayout className="tfh-home">
       <Grid row gap={6} className="tfh-hp-top">
         <Grid tablet={{ col: 8 }} className="tfh-hp-highlight">
           <h2 className="tfh-hp-highlight-h2 font-heading-xl">
@@ -51,7 +51,7 @@ const IndexPage: React.FC<PageProps<Queries.HomePageInitiativesQuery>> = ({
           />
         </Grid>
         <Grid tablet={{ col: 4 }} className="tfh-hp-right-nav">
-          <hr className="text-accent-warm bg-accent-warm" />
+          <hr className="bg-primary-dark" />
           <h3>01. Get Started</h3>
           <ol>
             <li>
@@ -64,7 +64,7 @@ const IndexPage: React.FC<PageProps<Queries.HomePageInitiativesQuery>> = ({
               <a href="https://github.com/usds/techfar-hub-website-v3">How to Get Involved</a>
             </li>
           </ol>
-          <hr className="text-accent-cool-dark bg-accent-cool-dark" />
+          <hr className="bg-primary-dark" />
           <h3>02. TFH Lifecycle</h3>
           <p>See how the TechFAR Hub takes an agile approach to digital acquisition.</p>
           <ol>
@@ -81,7 +81,7 @@ const IndexPage: React.FC<PageProps<Queries.HomePageInitiativesQuery>> = ({
               <Link to="/contract-administration/">Contract Administration</Link>
             </li>
           </ol>
-          <hr className="text-green bg-green " />
+          <hr className="bg-primary-dark" />
           <h3>03. Resources</h3>
           <p>View first-hand experiences of fellows acquisition professionals, get tools, access training, and more</p>
           <ol>


### PR DESCRIPTION
This PR

- Fixes the homepage colors
- Centers the nav
- Make the summary box an alert box
- Generally brings the site design closer to the mocks
- Get the USDS logo into the header